### PR TITLE
修改无法取消下载请求的问题

### DIFF
--- a/nohttp/src/main/java/com/yanzhenjie/nohttp/BasicRequest.java
+++ b/nohttp/src/main/java/com/yanzhenjie/nohttp/BasicRequest.java
@@ -139,6 +139,7 @@ public class BasicRequest<T extends BasicRequest> implements Comparable<BasicReq
      * Cancel sign.
      */
     private Object mCancelSign;
+
     /**
      * Tag of handle.
      */
@@ -1120,11 +1121,20 @@ public class BasicRequest<T extends BasicRequest> implements Comparable<BasicReq
     }
 
     /**
-     * Set tag of task, At the end of the task is returned to you.
+     * Set tag of task, you can use this mTag cancel this request ,
+     * but this tag should uniqueness,
+     * At the end of the task is returned to you.
      */
     public T setTag(Object tag) {
         this.mTag = tag;
         return (T) this;
+    }
+
+    /**
+     * @return mTag
+     */
+    public Object getmTag() {
+        return mTag;
     }
 
     /**

--- a/nohttp/src/main/java/com/yanzhenjie/nohttp/BasicRequest.java
+++ b/nohttp/src/main/java/com/yanzhenjie/nohttp/BasicRequest.java
@@ -1131,13 +1131,6 @@ public class BasicRequest<T extends BasicRequest> implements Comparable<BasicReq
     }
 
     /**
-     * @return mTag
-     */
-    public Object getmTag() {
-        return mTag;
-    }
-
-    /**
      * Should to return the tag of the object.
      */
     public Object getTag() {
@@ -1242,6 +1235,10 @@ public class BasicRequest<T extends BasicRequest> implements Comparable<BasicReq
     public T setCancelSign(Object sign) {
         this.mCancelSign = sign;
         return (T) this;
+    }
+
+    public Object getCancelSign(){
+        return mCancelSign;
     }
 
     /**

--- a/nohttp/src/main/java/com/yanzhenjie/nohttp/download/DownloadDispatcher.java
+++ b/nohttp/src/main/java/com/yanzhenjie/nohttp/download/DownloadDispatcher.java
@@ -29,17 +29,21 @@ import java.util.concurrent.BlockingQueue;
  * Created in Oct 21, 2015 2:46:23 PM.
  *
  * @author Yan Zhenjie.
+ *
+ * modify zhangnn on  2018-1-31-21:55
  */
 class DownloadDispatcher extends Thread {
 
     private final BlockingQueue<DownloadRequest> mRequestQueue;
     private final Map<DownloadRequest, Messenger> mMessengerMap;
+    private final IDownloadRequestListener downloadRequestListener;
 
     private boolean mQuit = false;
 
-    public DownloadDispatcher(BlockingQueue<DownloadRequest> requestQueue, Map<DownloadRequest, Messenger> messengerMap) {
+    public DownloadDispatcher(BlockingQueue<DownloadRequest> requestQueue, Map<DownloadRequest, Messenger> messengerMap,IDownloadRequestListener downloadRequestListener) {
         this.mRequestQueue = requestQueue;
         this.mMessengerMap = messengerMap;
+        this.downloadRequestListener = downloadRequestListener;
     }
 
     /**
@@ -71,7 +75,7 @@ class DownloadDispatcher extends Thread {
             }
 
             request.start();
-            SyncDownloadExecutor.INSTANCE.execute(0, request, new ListenerDelegate(request, mMessengerMap));
+            SyncDownloadExecutor.INSTANCE.execute(0, request, new ListenerDelegate(request, mMessengerMap),downloadRequestListener);
             request.finish();
 
             // remove it from queue.

--- a/nohttp/src/main/java/com/yanzhenjie/nohttp/download/IDownloadRequestListener.java
+++ b/nohttp/src/main/java/com/yanzhenjie/nohttp/download/IDownloadRequestListener.java
@@ -1,0 +1,34 @@
+package com.yanzhenjie.nohttp.download;
+
+/**
+ * Project Name: NoHttp
+ * Package Name:com.yanzhenjie.nohttp.download
+ * Author: zhangnn
+ * Create Time: 2018/1/31 下午 9:00
+ * Remark: describe this class purpose
+ * Note:监听下载请求的执行状态
+ */
+
+public interface IDownloadRequestListener {
+
+    /**
+     * 请求开始执行
+     *
+     * @param what 请求的唯一标识
+     */
+    void onStart(int what);
+
+    /**
+     * 请求正常结束
+     *
+     * @param what 请求的唯一标识
+     */
+    void onFinish(int what);
+
+    /**
+     * 请求出错
+     *
+     * @param what 请求的唯一标识
+     */
+    void onError(int what);
+}

--- a/nohttp/src/main/java/com/yanzhenjie/nohttp/download/SyncDownloadExecutor.java
+++ b/nohttp/src/main/java/com/yanzhenjie/nohttp/download/SyncDownloadExecutor.java
@@ -20,6 +20,8 @@ import com.yanzhenjie.nohttp.NoHttp;
 /**
  * <p>Synchronize File Downloader.</p>
  * Created by Yan Zhenjie on 2016/10/12.
+ *
+ * modify zhangnn on  2018-1-31-21:55
  */
 public enum SyncDownloadExecutor {
 
@@ -38,7 +40,7 @@ public enum SyncDownloadExecutor {
      * @param downloadRequest {@link DownloadRequest}.
      * @param listener        accept various download status callback..
      */
-    public void execute(int what, DownloadRequest downloadRequest, DownloadListener listener) {
-        mDownloader.download(what, downloadRequest, listener);
+    public void execute(int what, DownloadRequest downloadRequest, DownloadListener listener,IDownloadRequestListener downloadRequestListener) {
+        mDownloader.download(what, downloadRequest, listener,downloadRequestListener);
     }
 }


### PR DESCRIPTION
问题如下：
1，如果一个下载的请求正在被执行，发起取消，不能被正确执行，原因队列中已经不存在这个请求；
2，如果一个下载的请求正在执行，重新添加，会再次被添加到队列中，修复方法，添加请求的时候判断该请求是否已经存在，如果存在，不在进行重复添加